### PR TITLE
SW-240 fix mount manager folder deletions on startup (#70)

### DIFF
--- a/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_add.service
+++ b/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_add.service
@@ -1,0 +1,6 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mount_manager add
+
+[Unit]
+After=mount_manager_remove.service

--- a/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_clear.service
+++ b/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_clear.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=runs the mount_manager clear command
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mount_manager clear
+
+[Install]
+WantedBy=shutdown.target

--- a/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_remove.service
+++ b/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_remove.service
@@ -1,3 +1,3 @@
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/bin/mount_manager remove

--- a/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_remove_before_octo.service
+++ b/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/mount_manager_remove_before_octo.service
@@ -1,0 +1,10 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mount_manager remove
+
+[Unit]
+Description=runs mount_manager remove as a tartup process before OctoPrint.
+Before=octoprint.service
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/usb_mount_manager_add.service
+++ b/src/modules/beamos/filesystem/mount_manager/root/etc/systemd/system/usb_mount_manager_add.service
@@ -1,3 +1,0 @@
-[Service]
-Type=simple
-ExecStart=/usr/bin/mount_manager add

--- a/src/modules/beamos/start_chroot_script
+++ b/src/modules/beamos/start_chroot_script
@@ -378,8 +378,8 @@ pushd /home/pi
     apt-install gnupg zip unzip
     unpack /filesystem/mount_manager/root / root
     unpack /filesystem/mount_manager/home /home/ pi
-    echo 'ACTION=="add",SUBSYSTEM=="block",KERNEL=="sd*[!0-9]",TAG+="systemd",ENV{SYSTEMD_WANTS}="usb_mount_manager_add.service"' >> /lib/udev/rules.d/00-mount_manager.rules
-    echo 'ACTION=="remove",SUBSYSTEM=="block",KERNEL=="sd*[!0-9]",RUN+="/bin/systemctl start --no-block usb_mount_manager_remove.service"' >> /lib/udev/rules.d/00-mount_manager.rules
+    echo 'ACTION=="add",SUBSYSTEM=="block",KERNEL=="sd*[!0-9]",TAG+="systemd",ENV{SYSTEMD_WANTS}="mount_manager_add.service"' >> /lib/udev/rules.d/00-mount_manager.rules
+    echo 'ACTION=="remove",SUBSYSTEM=="block",KERNEL=="sd*[!0-9]",RUN+="/bin/systemctl start --no-block mount_manager_remove.service"' >> /lib/udev/rules.d/00-mount_manager.rules
     # mount manager was cloned as a submodule to /filesystem before running the script
     mv /filesystem/repos/mount_manager/mount_manager/mount_manager /usr/bin/
     chmod +x /usr/bin/mount_manager
@@ -392,6 +392,10 @@ pushd /home/pi
     # sudo -u "${BASE_USER}" gpg --import /usr/share/mount_manager/pubkey.asc
     # The daemon gpg-agent can make the system hang when umouting the chroot image
     gpgconf --kill gpg-agent
+    systemctl enable mount_manager_add.service
+    systemctl enable mount_manager_remove.service
+    systemctl enable mount_manager_remove_before_octo.service
+    systemctl enable mount_manager_clear.service
   fi
   if [ "$BEAMOS_INCLUDE_FINDMYMRBEAM" = "yes" ]
   then

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -163,8 +163,6 @@ echo "${BASE_USER} ALL=NOPASSWD: /usr/sbin/service" > /etc/sudoers.d/octoprint-s
 # Note, this code is also in /filesystem/home/pi/scripts/
 sed -i 's@exit 0@@' /etc/rc.local
 cat <<'EOT' >> /etc/rc.local
-# clear mount_manager leftovers
-/usr/bin/mount_manager clear
 
 echo
 echo "------------------------------------------------------------"


### PR DESCRIPTION
- Handle mount_manager using systemd insterad of rc.local
- removed change to rc.local
- Fix path to service files.
- Fix systemd units/services.
- Update mount_manager commit hash
- Add secondary mount manager remove service to run only on boot.

Co-authored-by: alexloss <axel@soll.xyz>