### PR TITLE
SW-4169 add migration service

### DIFF
--- a/src/modules/beamos/filesystem/migration/etc/systemd/system/migrationos_to_beamos2.service
+++ b/src/modules/beamos/filesystem/migration/etc/systemd/system/migrationos_to_beamos2.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Migration Service
-After=network.target
+After=mrbeam_ledstrips.service socket.service
 
 [Service]
 Type=simple
-ExecStart=/bin/bash /usr/bin/migrationos_to_beamos2.sh
+# add a delay to make sure ledstrips are up and running
+ExecStartPre=/bin/sleep 10
+ExecStart=/usr/bin/migrationos_to_beamos2.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/src/modules/beamos/filesystem/migration/etc/systemd/system/migrationos_to_beamos2.service
+++ b/src/modules/beamos/filesystem/migration/etc/systemd/system/migrationos_to_beamos2.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Migration Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /usr/bin/migrationos_to_beamos2.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/beamos/start_chroot_script
+++ b/src/modules/beamos/start_chroot_script
@@ -534,8 +534,7 @@ sudo apt-get install -y bmap-tools
 
 # Copy migrationos.sh and migrationos_to_beamos2.sh to /usr/bin
 unpack /filesystem/migration / root
-
-# TODO: SW-4169 Add migration service to run migrationos_to_beamos2.sh on boot
+systemctl_if_exists enable migrationos_to_beamos2.service
 
 #####################################################################
 ### setup systemd units/services


### PR DESCRIPTION
* Add a service to run on boot of migrationos.
* The service triggers the migrationos_to_beamos2.sh
* Add to the chroot script to include in build.